### PR TITLE
Support for send documents and fix previous change that broke post (issue #8)

### DIFF
--- a/classes/RightSignature.php
+++ b/classes/RightSignature.php
@@ -108,6 +108,19 @@ class RightSignature
         // return Document::list($this->_client);
     }
 
+    /**
+     * This method is for sending a once-off document that has not been setup as a Template.
+     *
+     * @param string $path Path of the document to send
+     * @param array  $args Arguments to use as payload
+     *
+     * @return array
+     */
+    public function sendDocument($path, $args)
+    {
+        return Document::send($this->_client, $path, $args);
+    }
+
     // ----------------------------------------
     // Signer Links
 

--- a/classes/RightSignature/HttpClient.php
+++ b/classes/RightSignature/HttpClient.php
@@ -79,18 +79,23 @@ class HttpClient implements HttpClientInterface
      */
     public function post($path, $body = null)
     {
-        $postRequest = [
-            $path, [
-                'headers' => $this->_getHeaders(),
-                'verify' => $this->_verifySSL,
-            ],
+        // request options
+        $options = [
+            'headers' => $this->_getHeaders(),
+            'verify' => $this->_verifySSL,
         ];
 
+        // determinate data to send
         if (is_array($body)) {
-            $postRequest['form_params'] = $body;
-        } else {
-            $postRequest['body'] = $body;
+            $options['form_params'] = $body;
+        } else if (is_string($body)) {
+            $options['body'] = $body;
         }
+
+        $postRequest = [
+            $path,
+            $options,
+        ];
 
         return $this->_submit('post', $postRequest);
     }

--- a/tests/RightSignature/DocumentTest.php
+++ b/tests/RightSignature/DocumentTest.php
@@ -113,29 +113,29 @@ EOS;
     public function testSendDocument()
     {
         $response = <<<EOS
-<?xml version="1.0" encoding="UTF-8"?>
-<document>
-	<status>sent</status>
-	<guid>2VMW88J3424MPEYF9DU6VY</guid>
-</document>
+            <?xml version="1.0" encoding="UTF-8"?>
+            <document>
+                <status>sent</status>
+                <guid>2VMW88J3424MPEYF9DU6VY</guid>
+            </document>
 EOS;
         $payload = [
-          'subject' => '- email subject -',
-          'action' => 'send',
-          'type' => 'base64',
-          'recipients' => [
-              'recipient' => [
-                  [
-                      'is_sender' => true,
-                      'role' => 'cc',
-                  ],
-                  [
-                      'name' => 'Signer 1',
-                      'email' => 'pjafwcyv@sharklasers.com',
-                      'role' => 'signer',
-                  ],
-              ],
-          ],
+            'subject' => '- email subject -',
+            'action' => 'send',
+            'type' => 'base64',
+            'recipients' => [
+                'recipient' => [
+                    [
+                        'is_sender' => true,
+                        'role' => 'cc',
+                    ],
+                    [
+                        'name' => 'Signer 1',
+                        'email' => 'pjafwcyv@sharklasers.com',
+                        'role' => 'signer',
+                    ],
+                ],
+            ],
         ];
 
         $client = \Mockery::mock('client');

--- a/tests/RightSignature/DocumentTest.php
+++ b/tests/RightSignature/DocumentTest.php
@@ -113,7 +113,6 @@ EOS;
     public function testSendDocument()
     {
         $response = <<<EOS
-            <?xml version="1.0" encoding="UTF-8"?>
             <document>
                 <status>sent</status>
                 <guid>2VMW88J3424MPEYF9DU6VY</guid>

--- a/tests/RightSignature/DocumentTest.php
+++ b/tests/RightSignature/DocumentTest.php
@@ -142,12 +142,11 @@ EOS;
                 ->withAnyArgs()
                 ->andReturn($response);
 
-        $file = fopen('sample-file.pdf', 'w');
-        fwrite($file, '- test document to sign -');
-        fclose($file);
+        $tmp = tmpfile();
+        fwrite($tmp, '- test document to sign -');
+        $meta = stream_get_meta_data($tmp);
 
-        $document = Document::send($client, 'sample-file.pdf', $payload);
-        @unlink('sample-file.pdf');
+        $document = Document::send($client, $meta['uri'], $payload);
 
         $this->assertEquals('sent', $document['status']);
     }

--- a/tests/RightSignature/DocumentTest.php
+++ b/tests/RightSignature/DocumentTest.php
@@ -119,25 +119,24 @@ EOS;
 	<guid>2VMW88J3424MPEYF9DU6VY</guid>
 </document>
 EOS;
-
         $payload = [
-			'subject' => '- email subject -',
-			'action' => 'send',
-			'type' => 'base64',
-			'recipients' => [
-				'recipient' => [
-					[
-						'is_sender' => true,
-						'role' => 'cc',
-					],
-					[
-						'name' => 'Signer 1',
-						'email' => 'pjafwcyv@sharklasers.com',
-						'role' => 'signer',
-					],
-				],
-			],
-		];
+          'subject' => '- email subject -',
+          'action' => 'send',
+          'type' => 'base64',
+          'recipients' => [
+              'recipient' => [
+                  [
+                      'is_sender' => true,
+                      'role' => 'cc',
+                  ],
+                  [
+                      'name' => 'Signer 1',
+                      'email' => 'pjafwcyv@sharklasers.com',
+                      'role' => 'signer',
+                  ],
+              ],
+          ],
+        ];
 
         $client = \Mockery::mock('client');
         $client->shouldReceive('post')


### PR DESCRIPTION
Adding support for send documents, Fixing bug with Request Options and guzzle, body and form_params, [issue #8](https://github.com/99designs/rightsignature-php/issues/8)
